### PR TITLE
Allow extra environment settings

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -14,7 +14,12 @@ UnitsLiteral = Literal["mm", "in"]
 class Settings(BaseSettings):
     """Central application settings loaded from environment variables."""
 
-    model_config = SettingsConfigDict(env_file=".env", env_prefix="", case_sensitive=False)
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_prefix="",
+        case_sensitive=False,
+        extra="ignore",
+    )
 
     default_units: UnitsLiteral = Field(
         default="mm",


### PR DESCRIPTION
## Summary
- allow the application settings loader to ignore extra environment variables
- ensures tests can set AI_PROVIDER without failing validation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d57da8820083208937610af270d6c6